### PR TITLE
docs: started typing  _setup, Setup, and cfg

### DIFF
--- a/lua/telekasten.lua
+++ b/lua/telekasten.lua
@@ -2751,6 +2751,7 @@ end
 --
 -- Overrides config with elements from cfg. See top of file for defaults.
 --
+---@param cfg VaultConfig
 local function Setup(cfg)
     cfg = cfg or {}
 
@@ -2849,6 +2850,17 @@ local function Setup(cfg)
     config.options.media_extensions = config.options.media_extensions
 end
 
+---Type in progress
+---@class VaultConfig
+---@field home string
+
+---@class MultiVaultConfig
+---@field vaults table<string, VaultConfig>
+---@field default_vault? string
+
+--- Wrapper around the Setup function to handle cfgs variable input type
+--- Try the specified key -> vault as default, then the "default" -> vault, then its a VaultConfig
+---@param cfg MultiVaultConfig | VaultConfig
 local function _setup(cfg)
     if cfg.vaults ~= nil and cfg.default_vault ~= nil then
         M.vaults = cfg.vaults
@@ -2861,6 +2873,7 @@ local function _setup(cfg)
     elseif cfg.home ~= nil then
         M.vaults = cfg.vaults or {}
         cfg.vaults = nil
+        ---@cast cfg VaultConfig
         M.vaults["default"] = cfg
         Setup(cfg)
     end


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
  Please note: we want to avoid breaking changes at all cost
-->

Lua language server is really good at type checking, so I'm adding some type hints. I like types. You can agree or disagree on that one.

## Type of change

<!--
  What type of change does your PR introduce to Telekasten?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [x] Code quality improvements to existing code or addition of tests
- [x] Documentation update

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] I am running the **latest** version of the plugin.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Stylua (a `.stylua.toml` file is provided)
- [x] The code has been checked with luacheck (a `.luacheckrc` file is provided)
- [x] The `README.md` has been updated according to this change.
- [x] The `doc/telekasten.txt` helpfile has been updated according to this change.

<!--
  Thank you for contributing <3
-->
