### PR TITLE
Refactor and type config.lua

### DIFF
--- a/.luarc.json
+++ b/.luarc.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/LuaLS/vscode-lua/master/setting/schema.json",
+  "workspace.library": ["lua"],
+  "runtime.version": "Lua 5.4",
+  "hint.enable": false
+}
+

--- a/lua/telekasten.lua
+++ b/lua/telekasten.lua
@@ -1809,9 +1809,9 @@ local function FindAllTags(opts)
 end
 
 --- Setup(cfg)
--- Overrides config with elements from cfg. See lua/telekasten/config.lua for defaults.
--- @param cfg table Table of configuration values to override defaults
--- Maybe fold into _setup? Also used in chdir, though...
+--- Overrides config with elements from cfg. See lua/telekasten/config.lua for defaults.
+--- Maybe fold into _setup? Also used in chdir, though...
+---@param cfg VaultConfig table of configuration values to override defaults
 local function Setup(cfg)
     cfg = cfg or {}
 
@@ -1912,9 +1912,17 @@ local function Setup(cfg)
     config.options.media_extensions = config.options.media_extensions
 end
 
+---Type in progress
+---@class VaultConfig
+---@field home string
+
+---@class MultiVaultConfig
+---@field vaults table<string, VaultConfig>
+---@field default_vault? string
+
 --- _setup(cfg)
 -- Sets the available vaults and passes further configuration options to Setup
--- @param cfg table Table of configuration values
+---@param cfg MultiVaultConfig | VaultConfig table of configuration values
 local function _setup(cfg)
     if cfg.vaults ~= nil and cfg.default_vault ~= nil then
         M.vaults = cfg.vaults
@@ -1927,6 +1935,7 @@ local function _setup(cfg)
     elseif cfg.home ~= nil then
         M.vaults = cfg.vaults or {}
         cfg.vaults = nil
+        ---@cast cfg VaultConfig
         M.vaults["default"] = cfg
         Setup(cfg)
     end

--- a/lua/telekasten.lua
+++ b/lua/telekasten.lua
@@ -1912,14 +1912,6 @@ local function Setup(cfg)
     config.options.media_extensions = config.options.media_extensions
 end
 
----Type in progress
----@class VaultConfig
----@field home string
-
----@class MultiVaultConfig
----@field vaults table<string, VaultConfig>
----@field default_vault? string
-
 --- _setup(cfg)
 -- Sets the available vaults and passes further configuration options to Setup
 ---@param cfg MultiVaultConfig | VaultConfig table of configuration values

--- a/lua/telekasten/config.lua
+++ b/lua/telekasten/config.lua
@@ -6,11 +6,17 @@ local M = {}
 
 ---The local class instance of the merged user's configuration this includes all
 ---default values and highlights filled out
+---@type Config
 local config = {}
 
 ---The class definition for the user configuration
+---@class Config
+---@field options VaultConfig
+---@field user {options: VaultConfig}
 local Config = {}
 
+---@param opts VaultConfig
+---@return Config
 function Config:new(opts)
     local o = { options = opts }
     assert(o, "User options must be passed in")
@@ -24,6 +30,8 @@ function Config:new(opts)
 end
 
 ---Combine user preferences with defaults preferring the user's own settings
+---@param defaults {options: VaultConfig}
+---@return Config
 function Config:merge(defaults)
     assert(
         defaults and type(defaults) == "table",
@@ -34,10 +42,11 @@ function Config:merge(defaults)
     return self
 end
 
---
--- Default setup. Ideally anyone should be able to start using Telekasten
--- directly without fiddling too much with the options. The only one of real
--- interest should be the path for the few relevant directories.
+--- Default setup. Ideally anyone should be able to start using Telekasten
+--- directly without fiddling too much with the options. The only one of real
+--- interest should be the path for the few relevant directories.
+---@param home string | nil
+---@return {options: VaultConfig}
 local function get_defaults(home)
     local _home = home or vim.fn.expand("~/zettelkasten") -- Default home directory
     local opts = {
@@ -97,6 +106,7 @@ local function get_defaults(home)
 end
 
 --- Merge user config with defaults
+---@return Config
 function M.apply()
     local defaults = get_defaults(config.options.home)
     config:merge(defaults)
@@ -110,7 +120,8 @@ function M.setup(c)
     M.apply()
 end
 
----Get the user's configuration or a key from it
+---Get the user's configuration
+---@return Config | nil
 function M.get()
     if config then
         return config

--- a/lua/telekasten/config.lua
+++ b/lua/telekasten/config.lua
@@ -2,6 +2,7 @@
 --
 local vim = vim
 
+---@class M: Config
 local M = {}
 
 ---The local class instance of the merged user's configuration this includes all

--- a/lua/telekasten/utils/definitions.lua
+++ b/lua/telekasten/utils/definitions.lua
@@ -1,0 +1,58 @@
+---@meta
+
+---@alias MediaExtensions
+---| '".png"'
+---| '".jpg"'
+---| '".bmp"'
+---| '".gif"'
+---| '".pdf"'
+---| '".mp4"'
+---| '".webm"'
+---| '".webp"'
+
+---@class VaultConfig
+---@field home string
+---@field take_over_my_home boolean
+---@field auto_set_filetype boolean
+---@field auto_set_syntax boolean
+---@field dailies string
+---@field weeklies string
+---@field templates string
+---@field image_subdir string|nil -- Should be deprecated gracefully and replaced by "images"
+---@field extension string
+---@field new_note_filename string
+---@field uuid_type string
+---@field uuid_sep string
+---@field filename_space_subst string|nil
+---@field follow_creates_nonexisting boolean
+---@field dailies_create_nonexisting boolean
+---@field weeklies_create_nonexisting boolean
+---@field journal_auto_open boolean
+---@field image_link_style string
+---@field sort string
+---@field subdirs_in_links boolean
+---@field plug_into_calendar boolean
+---@field calendar_opts CalendarOpts
+---@field close_after_yanking boolean
+---@field insert_after_inserting boolean
+---@field tag_notation string
+---@field command_palette_theme string
+---@field show_tags_theme string
+---@field template_handling string
+---@field new_note_location string
+---@field rename_update_links boolean
+---@field media_previewer string
+---@field media_extensions MediaExtensions[]
+---@field follow_url_fallback string|nil
+---@field enable_create_new boolean
+---@field clipboard_program string
+---@field filter_extensions string[]
+
+---@class CalendarOpts
+---@field weeknm number
+---@field calendar_monday number
+---@field calendar_mark string
+
+---@class MultiVaultConfig
+---@field vaults table<string, VaultConfig>
+---@field default_vault? string

--- a/lua/telekasten/utils/definitions.lua
+++ b/lua/telekasten/utils/definitions.lua
@@ -1,3 +1,4 @@
+--luacheck: ignore 211
 ---@meta
 
 ---@alias MediaExtensions
@@ -19,45 +20,67 @@
 ---@field weeklies string
 ---@field templates string
 ---@field image_subdir string|nil Should be deprecated gracefully and replaced by "images"
----@field extension string
----@field new_note_filename string
----@field uuid_type string
----@field uuid_sep string
+---@field extension "md" | string
+---@field new_note_filename "title" | "uuid" | "uuid-title"
+---@field uuid_type "%Y%m%d%H%M" | string
+---@field uuid_sep "-" | string
 ---@field filename_space_subst string|nil
 ---@field follow_creates_nonexisting boolean
 ---@field dailies_create_nonexisting boolean
 ---@field weeklies_create_nonexisting boolean
 ---@field journal_auto_open boolean
----@field image_link_style string
----@field sort string
+---@field image_link_style "wiki" | "markdown"
+---@field sort "filename" | "modified"
 ---@field subdirs_in_links boolean
 ---@field plug_into_calendar boolean
 ---@field calendar_opts CalendarOpts
 ---@field close_after_yanking boolean
 ---@field insert_after_inserting boolean
----@field tag_notation string
----@field command_palette_theme string
+---@field tag_notation "#tag" | "@tag" | ":tag:" | "yaml-bare"
+---@field command_palette_theme "dropdown" | "ivy"
 ---@field show_tags_theme string
----@field template_handling string
----@field new_note_location string
+---@field template_handling "smart" | "prefer_new_note" | "always_ask"
+---@field new_note_location "smart" |"prefer_home" |  "same_as_current"
 ---@field rename_update_links boolean
----@field media_previewer string
+---@field media_previewer "telescope-media-files" | "catimg-previewer" | "viu-previewer"
 ---@field media_extensions MediaExtensions[]
 ---@field follow_url_fallback string|nil
 ---@field enable_create_new boolean
 ---@field clipboard_program string
 ---@field filter_extensions string[]
----@field template_new_note string
----@field template_new_daily string
----@field template_new_weekly string
+---@field template_new_note string|nil
+---@field template_new_daily string|nil
+---@field template_new_weekly string|nil
 ---@field find_command string[]
 ---@field rg_pcre boolean
+---
+---For defaults,
+---@see Config.get_defaults
+local VaultConfig = {}
+
+---@alias WeekNumberFormat
+---| 1 # WK01
+---| 2 # WK 1
+---| 3 # KW01
+---| 4 # KW 1
+---| 5 # 1
+
+---@alias CalendarStartDay
+---| 0 # weeks start on Sundays
+---| 1 # weeks start on Mondays
+
+---@alias CalendarMarkPosition
+---| 'left'     # ugly
+---| 'right'    # right to the day
+---| 'left-fit' # left of the day
 
 ---@class CalendarOpts
----@field weeknm number
----@field calendar_monday number
----@field calendar_mark string
+---@field weeknm WeekNumberFormat
+---@field calendar_monday CalendarStartDay
+---@field calendar_mark CalendarMarkPosition
+local CalendarOpts = {}
 
 ---@class MultiVaultConfig
 ---@field vaults table<string, VaultConfig>
 ---@field default_vault? string
+local MultiVaultConfig = {}

--- a/lua/telekasten/utils/definitions.lua
+++ b/lua/telekasten/utils/definitions.lua
@@ -18,7 +18,7 @@
 ---@field dailies string
 ---@field weeklies string
 ---@field templates string
----@field image_subdir string|nil -- Should be deprecated gracefully and replaced by "images"
+---@field image_subdir string|nil Should be deprecated gracefully and replaced by "images"
 ---@field extension string
 ---@field new_note_filename string
 ---@field uuid_type string
@@ -47,6 +47,11 @@
 ---@field enable_create_new boolean
 ---@field clipboard_program string
 ---@field filter_extensions string[]
+---@field template_new_note string
+---@field template_new_daily string
+---@field template_new_weekly string
+---@field find_command string[]
+---@field rg_pcre boolean
 
 ---@class CalendarOpts
 ---@field weeknm number


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
  Please note: we want to avoid breaking changes at all cost
-->

Adds more type checking based on https://luals.github.io/wiki/ primarily to config.lua and refactors config.lua to have less unnecessary indirection. This should only modify config.lua internally. I tested by printing the config table that is returned from requiring config.lua and it looks correct, although I have a simple config, but it is merging the defaults with it still.


```lua
-- user config
{
  options = {
    home = "/home/ujisati/.notes",
    plug_into_calendar = false
  }
}

require"telekasten.config".debug()
-- returns
{
  auto_set_filetype = true,
  auto_set_syntax = true,
  calendar_opts = {
    calendar_mark = "left-fit",
    calendar_monday = 1,
    weeknm = 4
  },
  clipboard_program = "",
  close_after_yanking = false,
  command_palette_theme = "ivy",
  dailies = "/home/ujisati/.notes",
  dailies_create_nonexisting = true,
  enable_create_new = true,
  extension = ".md",
  filter_extensions = { ".md" },
  find_command = { "rg", "--files", "--sortr", "created" },
  follow_creates_nonexisting = true,
  home = "/home/ujisati/.notes",
  image_link_style = "markdown",
  insert_after_inserting = true,
  journal_auto_open = false,
  media_extensions = { ".png", ".jpg", ".bmp", ".gif", ".pdf", ".mp4", ".webm", ".webp" },
  media_previewer = "telescope-media-files",
  new_note_filename = "title",
  new_note_location = "smart",
  plug_into_calendar = false,
  rename_update_links = true,
  rg_pcre = false,
  show_tags_theme = "ivy",
  sort = "filename",
  subdirs_in_links = true,
  tag_notation = "#tag",
  take_over_my_home = true,
  template_handling = "smart",
  template_new_daily = "none",
  template_new_note = "none",
  template_new_weekly = "none",
  templates = "/home/ujisati/.notes",
  uuid_sep = "-",
  uuid_type = "%Y%m%d%H%M",
  weeklies = "/home/ujisati/.notes",
  weeklies_create_nonexisting = true
}
```


Let me know how useful ya'll think this kind of documentation is. Typing config.lua made it a lot easier to refactor, FWIW.

## Type of change

<!--
  What type of change does your PR introduce to Telekasten?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [x] Code quality improvements to existing code or addition of tests
- [x] Documentation update

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
https://github.com/nvim-telekasten/telekasten.nvim/pull/332#issuecomment-2171881590
More info about about lua language server

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] I am running the **latest** version of the plugin.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Stylua (a `.stylua.toml` file is provided)
- [x] The code has been checked with luacheck (a `.luacheckrc` file is provided)
- [ ] The `README.md` has been updated according to this change.
- [ ] The `doc/telekasten.txt` helpfile has been updated according to this change.

<!--
  Thank you for contributing <3
-->
