### PR TITLE
 feat: Enhance note creation with custom extensions and improved filefiltering

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ switch between them easily. Simply add data to the `vaults` table in the
 Added support for filtering files in the vault based on multiple extensions. This can be configured by assigning a table with one or more file extensions in the configuration. Example:
 
 ```lua
-filter_extensions = { ".qmd", ".md", ".rmd" }
+filter_extensions = { ".md", ".qmd", ".rmd", ".norg", ".org" }
 ```
 This allows more flexible and comprehensive file type management within the vault.
 

--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ The following sub-commands are defined:
 - `follow_link` : Follow the link under the cursor
 - `goto_today` : Open today's daily note
 - `new_note` : Create a new note, prompts for title
+- `create_new_note_with_extension` : Create a new note with custom extension, prompts for title with extension
 - `goto_thisweek` : Open this week's weekly note
 - `find_weekly_notes` : Find weekly notes by title (calendar week)
 - `yank_notelink` : Yank a link to the currently open note
@@ -326,6 +327,14 @@ execution of a function to your specific need.
 Telekasten allows the user to have completely separated note collections and
 switch between them easily. Simply add data to the `vaults` table in the
     configuration and configure each vault as you wish.
+
+#### Files with different extensions in a vault
+Added support for filtering files in the vault based on multiple extensions. This can be configured by assigning a table with one or more file extensions in the configuration. Example:
+
+```lua
+filter_extensions = { ".qmd", ".md", ".rmd" }
+```
+This allows more flexible and comprehensive file type management within the vault.
 
 ### Link notation
 

--- a/doc/telekasten.txt
+++ b/doc/telekasten.txt
@@ -268,7 +268,14 @@ telekasten.setup({opts})
         Filename extension of your markdown note files.
 
         Default: '.md'
+                                   *telekasten.settings.filter_extensions*
+    filter_extensions: ~
+        Table with the filename extensions of your markdown note files.
+        You can use several markdown files like:
+        '{ ".norg", ".org", ".md", ".rmd", ".qmd" }'
 
+        Default: '{".md}'
+        
                                    *telekasten.settings.new_note_filename*
     new_note_filename: ~
         Configures the filenames of newly created notes. See |uuid_sep|
@@ -596,6 +603,15 @@ telekasten.new_templated_note()~
   opened immediately.
 
   See also:~
+      - |telekasten.template_files|
+                                *telekasten.create_new_note_with_extension()*
+telekasten.create_new_note_with_extension()~
+  Promts for a title and creates a new note which should inclue the extension
+  for the file by the `new_note` template, then shows it in Telescope.
+
+  See also:~
+      - |telekasten.settings.template_new_note|
+      - |telekasten.templates|
       - |telekasten.template_files|
                                                     *telekasten.find_notes()*
 telekasten.find_notes({opts})~

--- a/lua/telekasten.lua
+++ b/lua/telekasten.lua
@@ -3024,6 +3024,39 @@ local function chdir(cfg)
     -- M.Cfg = vim.tbl_deep_extend("force", defaultConfig(new_home), cfg)
 end
 
+local function CreateNoteWithCustomExtension()
+    vim.ui.input(
+        { prompt = "Title with extension (e.g., note.txt): " },
+        function(input)
+            if not input or input == "" then
+                print("Input is empty or nil")
+                return
+            end
+
+            local title, extension = input:match("(.+)%.([^%.]+)$")
+            if not title or not extension then
+                print(
+                    "Invalid format. Please include a file extension (e.g., note.txt)."
+                )
+                return
+            end
+
+            local sanitized_title = title:gsub("[^%w%s-]", ""):gsub("%s+", "_")
+            local filename_with_extension = sanitized_title .. "." .. extension
+
+            -- Temporarily set the file extension to an empty string to avoid adding it
+            local original_extension = M.Cfg.extension
+            M.Cfg.extension = ""
+
+            -- Call the on_create function with the sanitized title and extension
+            on_create({}, filename_with_extension)
+
+            -- Restore the original extension
+            M.Cfg.extension = original_extension
+        end
+    )
+end
+
 M.find_notes = FindNotes
 M.find_daily_notes = FindDailyNotes
 M.search_notes = SearchNotes
@@ -3032,6 +3065,7 @@ M.follow_link = FollowLink
 M.setup = _setup
 M.goto_today = GotoToday
 M.new_note = CreateNote
+M.create_new_note_with_extension = CreateNoteWithCustomExtension
 M.goto_thisweek = GotoThisWeek
 M.find_weekly_notes = FindWeeklyNotes
 M.yank_notelink = YankLink
@@ -3063,6 +3097,11 @@ local TelekastenCmd = {
             { "follow link", "follow_link", M.follow_link },
             { "goto today", "goto_today", M.goto_today },
             { "new note", "new_note", M.new_note },
+            {
+                "new note with custom extension",
+                "create_new_note_with_extension",
+                M.create_new_note_with_extension,
+            },
             { "goto thisweek", "goto_thisweek", M.goto_thisweek },
             { "find weekly notes", "find_weekly_notes", M.find_weekly_notes },
             { "yank link to note", "yank_notelink", M.yank_notelink },


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

New feature.
Enhanced the note creation functionality to handle custom file extensions provided by the user in a single input prompt. This update allows users to specify the note title and desired file extension together. The change ensures that the global M.Cfg.extension is temporarily overridden to prevent appending an additional default extension during file creation. Additionally, support for filtering files in the vault based on multiple extensions has been added, allowing more flexible file type management.

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
  Please note: we want to avoid breaking changes at all cost
-->

## Type of change
 New feature

<!--
  What type of change does your PR introduce to Telekasten?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

Added `CreateNoteWithCustomExtension` function to correctly handle custom file extensions provided by the user. The function now prompts the user to enter the note title with the desired extension in a single input. To avoid appending the globally defined extension, the global M.Cfg.extension is temporarily overridden during the file creation process.


Refactoring the custom extension handling function to support multiple extensions was challenging due to the extensive use of the global extension variable (M.Cfg.extension) across various inherited functions. This global dependency made it difficult to directly modify the extension handling without affecting core functionalities.

To enable file filtering in the vault based on multiple extensions, users can configure this by assigning a table with one or more file extensions in the configuration. Example:

```lua
filter_extensions = { ".qmd", ".md", ".rmd", ".org", ".norg" }
```

This enhancement addresses significant challenges due to existing dependencies on the global extension variable and improves file management within the vault.

adds the 

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #337
- This PR is related to issue: #337

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] I am running the **latest** version of the plugin.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Stylua (a `.stylua.toml` file is provided)
- [x] The code has been checked with luacheck (a `.luacheckrc` file is provided)
- [x] The `README.md` has been updated according to this change.
- [x] The `doc/telekasten.txt` helpfile has been updated according to this change.

<!--
  Thank you for contributing <3
-->
