### PR TITLE
fix: remove hard-coded "weekly" in folder creation prompt

### DIFF
--- a/lua/telekasten.lua
+++ b/lua/telekasten.lua
@@ -492,7 +492,7 @@ local function create_note_from_template(
 
     -- now write the output file, substituting vars line by line
     local file_dir = filepath:match("(.*/)") or ""
-    check_dir_and_ask(file_dir, "Create weekly dir", function(dir_succeed)
+    check_dir_and_ask(file_dir, "Notes", function(dir_succeed)
         if dir_succeed == false then
             return
         end


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
  Please note: we want to avoid breaking changes at all cost
-->

Replace hard-coded "Create weekly dir" in new folder creation prompt with more generic "Notes", resulting in the following:
- Previous: "Create weekly dir folder /home//projects/second-brain/foobar/ does not exist! Shall I create it?"
- New: "Notes folder /home/cameron/projects/second-brain/foobar/ does not exist! Shall I create it?"


## Type of change

<!--
  What type of change does your PR introduce to Telekasten?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Documentation update

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #297 

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] I am running the **latest** version of the plugin.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Stylua (a `.stylua.toml` file is provided)
- [x] The code has been checked with luacheck (a `.luacheckrc` file is provided)
- [ ] The `README.md` has been updated according to this change.
- [ ] The `doc/telekasten.txt` helpfile has been updated according to this change.

<!--
  Thank you for contributing <3
-->
